### PR TITLE
fix: Get the (g)vim executable path without hanging; Escape single quotes in Client.command; Quit more reliably; Return None when vim is showing an error during read_buffer(); and: Client.type() synchronously

### DIFF
--- a/vimrunner/vimrunner.py
+++ b/vimrunner/vimrunner.py
@@ -346,6 +346,7 @@ class Client(object):
             >>> client.command("ls")
 
         """
+        cmd = cmd.replace("'", "''")
         output = self.eval("VimrunnerPyEvaluateCommandOutput('%s')" % cmd)
         return output
         # could have been implemented like:

--- a/vimrunner/vimrunner.py
+++ b/vimrunner/vimrunner.py
@@ -548,6 +548,8 @@ class Client(object):
         """
         if not buf:
             buf = self.get_active_buffer()
+        if not buf:
+            return None
         return self.eval("getbufline(%s, %s, %s)" % (buf, lnum, end))
 
     def write_buffer(self, lnum, text):

--- a/vimrunner/vimrunner.py
+++ b/vimrunner/vimrunner.py
@@ -20,6 +20,7 @@ import shutil
 import multiprocessing
 import subprocess
 import random
+import re
 import time
 
 #vimrc = os.path.join(os.path.dirname(
@@ -337,7 +338,9 @@ class Client(object):
             >>> client.type(':ls <Enter>')
 
         """
-        self.server.remote_send(keys)
+        self.feedkeys(re.sub(r'(<\S+?>)', r'\\\1', keys))
+        # async version:
+        # self.server.remote_send(keys)
 
     def command(self, cmd):
         """Send commands to a Vim server.

--- a/vimrunner/vimrunner.py
+++ b/vimrunner/vimrunner.py
@@ -242,7 +242,7 @@ class Server(object):
         """Used to send to server the :qa! command. Useful when we connected
         to server instead of starting it in a subprocess with start().
         """
-        self.remote_send(':qa!<Enter>')
+        self.remote_expr('execute(":qa!")')
 
     def remote_send(self, keys):
         """Sends the given keys to Vim server. A wrapper around --remote-send.

--- a/vimrunner/vimrunner.py
+++ b/vimrunner/vimrunner.py
@@ -310,11 +310,14 @@ class Server(object):
     def _get_abs_path(exe):
         """Uses 'which' shell command to get the absolute path of the
         executable."""
-        path = subprocess.check_output([shutil.which(exe)])
-        # output from subprocess, sockets etc. is bytes even in py3, so
-        # convert it to unicode
-        path = path.decode('utf-8')
-        return path.strip('\n')
+        if hasattr(shutil, 'which'):
+            return shutil.which(exe)
+        else:
+            path = subprocess.check_output(['which', exe])
+            # output from subprocess, sockets etc. is bytes even in py3, so
+            # convert it to unicode
+            path = path.decode('utf-8')
+            return path.strip('\n')
 
 
 class Client(object):


### PR DESCRIPTION
Include fixes and changes from @liskin:

* Fix hang in _get_abs_path (in a py2 and py 3.0-3.2 compatible way)
    * e.g. when attempt to get (g)vim executable path
* Escape single quotes in Client.command
* Quit more reliably
* Return None when vim is showing an error during read_buffer()
* Implement Client.type using feedkeys, making it synchronous